### PR TITLE
Change submodule URL to https

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "libsilverline"]
 	path = libsilverline
-	url = git@github.com:SilverLineFramework/libsilverline.git
+	url = https://github.com/SilverLineFramework/libsilverline.git


### PR DESCRIPTION
The git@github.com URL does not work behind a corporate proxy.