### PR TITLE
fix: handle duplicate module UUID; default runtime to schedule 

### DIFF
--- a/pubsub/messages.py
+++ b/pubsub/messages.py
@@ -99,7 +99,7 @@ class UUIDNotFound(SLException):
 
     def __init__(self, obj, obj_type="runtime"):
         super().__init__(
-            {"desc": "invalid {} UUID".format(obj_type), "data": obj})
+            {"desc": "invalid {} Name/UUID".format(obj_type), "data": obj})
 
 
 class DuplicateUUID(SLException):


### PR DESCRIPTION
-handle duplicate module UUID better; now we check the state of the module
-default to schedule on pyruntime